### PR TITLE
Delete downloaded zip only if unzip is ok.

### DIFF
--- a/download_dataset.sh
+++ b/download_dataset.sh
@@ -1,3 +1,2 @@
 wget http://pix3d.csail.mit.edu/data/pix3d.zip
-unzip pix3d.zip
-rm pix3d.zip
+unzip pix3d.zip && rm pix3d.zip


### PR DESCRIPTION
I ran `download_dataset` script in a raw machine without `unzip` installed. Then after waiting a few minutes found nothing left. A small change but might make people with slow internet connection happier.